### PR TITLE
Add availability field to orderForm fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `availability` field to `OrderFormFragment`.
+
 ## [0.1.0] - 2019-09-05
 
-## Added
+### Added
 
 - Query: `orderForm`.
 - Mutations: `insertCoupon`, `updateItem`.

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -3,6 +3,7 @@ fragment OrderFormFragment on OrderForm {
     additionalInfo {
       brandName
     }
+    availability
     detailUrl
     id
     imageUrl


### PR DESCRIPTION
#### What problem is this solving?

~I hate PR descriptions like this, but this is exactly~ As the title says.

#### How should this be manually tested?

I've linked in [this workspace](https://resources--vtexgame1.myvtex.com/cart) this `checkout-resources` and a variation of `product-list` that displays the availability string for each product.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/19008/tratar-produtos-indisponíveis).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
