### PR TITLE
Feature/shipping info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Added
 
+- `Address` fragment to `OrderForm`.
+
+## Added
+
 - Shipping info to `OrderForm` fragment.
 - `EstimateShipping` mutation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+
+- Shipping info to `OrderForm` fragment.
+- `EstimateShipping` mutation.
+
 ## [0.5.0] - 2019-09-23
 
 ### Added

--- a/react/Mutations.js
+++ b/react/Mutations.js
@@ -1,7 +1,9 @@
+import estimateShipping from './mutations/estimateShipping.graphql'
 import insertCoupon from './mutations/insertCoupon.graphql'
 import updateItems from './mutations/updateItems.graphql'
 
 export default {
   insertCoupon,
+  estimateShipping,
   updateItems,
 }

--- a/react/fragments/address.graphql
+++ b/react/fragments/address.graphql
@@ -1,0 +1,14 @@
+fragment Address on Address {
+  addressId
+  addressType
+  city
+  complement
+  country
+  neighborhood
+  number
+  postalCode
+  receiverName
+  reference
+  state
+  street
+}

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -29,6 +29,37 @@ fragment OrderFormFragment on OrderForm {
     name
     value
   }
+  shipping {
+    countries
+    availableAddresses {
+      addressId
+      addressType
+      city
+      complement
+      country
+      neighborhood
+      number
+      postalCode
+      receiverName
+      reference
+      state
+      street
+    }
+    selectedAddress {
+      addressId
+      addressType
+      city
+      complement
+      country
+      neighborhood
+      number
+      postalCode
+      receiverName
+      reference
+      state
+      street
+    }
+  }
   messages {
     couponMessages {
       code

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -1,3 +1,5 @@
+#import './address.graphql'
+
 fragment OrderFormFragment on OrderForm {
   items {
     additionalInfo {
@@ -32,32 +34,10 @@ fragment OrderFormFragment on OrderForm {
   shipping {
     countries
     availableAddresses {
-      addressId
-      addressType
-      city
-      complement
-      country
-      neighborhood
-      number
-      postalCode
-      receiverName
-      reference
-      state
-      street
+      ...Address
     }
     selectedAddress {
-      addressId
-      addressType
-      city
-      complement
-      country
-      neighborhood
-      number
-      postalCode
-      receiverName
-      reference
-      state
-      street
+      ...Address
     }
   }
   messages {

--- a/react/mutations/estimateShipping.graphql
+++ b/react/mutations/estimateShipping.graphql
@@ -1,0 +1,8 @@
+# import '../fragments/orderForm.graphql'
+
+mutation estimateShipping($addressInput: AddressInput) {
+  estimateShipping(address: $addressInput)
+    @context(provider: "vtex.checkout-graphql") {
+    ...OrderFormFragment
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds shipping data to `OrderForm` fragment and also adds `estimateShipping` mutation. So, now `OrderShipping` can get the needed info. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/18320/implementar-consumer-do-order-shipping-no-shipping-calculator)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
