### PR TITLE
Add addToCart mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `addToCart` mutation.
+
 ## [0.8.0] - 2019-10-10
 
-## Added
+### Added
 
 - `DeliveryOptions` field to `OrderFormFragment`.
 
 ## [0.7.0] - 2019-09-24
 
-## Added
+### Added
 
 - `SelectDeliveryOption` mutation.
 
 ## [0.6.0] - 2019-09-24
 
-## Added
+### Added
 
 - `Address` fragment to `OrderForm`.
 
-## Added
+### Added
 
 - Shipping info to `OrderForm` fragment.
 - `EstimateShipping` mutation.
@@ -38,13 +42,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.4.0] - 2019-09-13
 
-## Added
+### Added
 
 - `messages` field with `couponMessages` to `OrderFormFragment`.
 
 ## [0.3.0] - 2019-09-11
 
-## Added
+### Added
 
 - MarketingData's message.
 

--- a/react/Mutations.js
+++ b/react/Mutations.js
@@ -1,11 +1,13 @@
+import addToCart from './mutations/addToCart.graphql'
 import estimateShipping from './mutations/estimateShipping.graphql'
 import insertCoupon from './mutations/insertCoupon.graphql'
-import updateItems from './mutations/updateItems.graphql'
 import selectDeliveryOption from './mutations/selectDeliveryOption.graphql'
+import updateItems from './mutations/updateItems.graphql'
 
 export default {
-  insertCoupon,
+  addToCart,
   estimateShipping,
+  insertCoupon,
   selectDeliveryOption,
   updateItems,
 }

--- a/react/mutations/addToCart.graphql
+++ b/react/mutations/addToCart.graphql
@@ -1,0 +1,7 @@
+# import '../fragments/orderForm.graphql'
+
+mutation addToCart($items: [ItemInput]) {
+  addToCart(items: $items) {
+    ...OrderFormFragment
+  }
+}


### PR DESCRIPTION
~_This PR depends on and **must** be merged after https://github.com/vtex/checkout-graphql/pull/29_~

#### What problem is this solving?

This adds the `addToCart` mutation added in https://github.com/vtex/checkout-graphql/pull/29 to `checkout-resources`, so it can be used by our front-end apps.

#### How should this be manually tested?

Use [this workspace](https://addtocart--vtexgame1.myvtex.com/cart), add any item and go to `/cart`. I've [replaced](https://github.com/vtex-apps/checkout-cart/compare/test/addtocart) the "Continue shopping" button by an "Add random item" button, which you can use to test the mutation.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/23743/mostrar-toast-no-carrinho-após-exclusão-de-produto-com-opção-para-desfazer-ação).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
