### PR TITLE
Add URLs to images with 2x and 3x resolutions to OrderForm fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `imageUrl` was replaced by `imageUrls`, which contain URLs to images with 1x, 2x and 3x resolutions.
+
 ## [0.9.0] - 2019-10-14
 
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -8,7 +8,11 @@ fragment OrderFormFragment on OrderForm {
     availability
     detailUrl
     id
-    imageUrl
+    imageUrls {
+      at1x
+      at2x
+      at3x
+    }
     listPrice
     measurementUnit
     name


### PR DESCRIPTION
#### What problem is this solving?

This adds URLs to 2x and 3x product images to the OrderForm. The main goal is to display those images on devices with retina screens.

#### How should this be manually tested?

[Go to cart](https://retina--checkoutio.myvtex.com/cart/add?sku=33) and check the URL of the image of the product. On 3x displays, the image URL should end with `288-auto`. On 2x displays, it should end with `192-auto` and on screens, it should end with `96-auto`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/21675/implementar-imagens-otimizadas-para-telas-retina).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
