### PR TITLE
Add new fields to orderForm query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `productCategories`, `productCategoryIds` and `productRefId` attributes to `orderForm` query.
+
 ## [0.11.0] - 2019-11-05
 
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -40,6 +40,9 @@ fragment OrderFormFragment on OrderForm {
     measurementUnit
     name
     price
+    productCategories
+    productCategoryIds
+    productRefId
     productId
     quantity
     sellingPrice


### PR DESCRIPTION
#### What problem is this solving?

Add `productCategories`, `productCategoryIds` and `productRefId` attributes to `orderForm` query.

#### How should this be manually tested?

[Workspace](https://minicart--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Depends on: https://github.com/vtex/checkout-graphql/pull/34
