### PR TITLE
Add canEditData field to OrderForm fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `canEditData` field to `OrderFormFragment`.
+
 ## [0.13.0] - 2019-12-06
 
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -53,6 +53,7 @@ fragment OrderFormFragment on OrderForm {
     }
     uniqueId
   }
+  canEditData
   marketingData {
     coupon
   }


### PR DESCRIPTION
#### Notes

This PR depends on and must be merged after [checkout-graphql](https://github.com/vtex/checkout-graphql/pull/36).

<!-- Put any relevant information that doesn't fit in the other sections here. -->

#### What problem is this solving?

`canEditData` field will provide the necessary info to the UI to decide if an identified user should be able to edit the existing `orderForm` data.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to [Workspace](https://fixskeleton--checkoutio.myvtex.com/cart)
- Verify that the button to edit postal code isn't available.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/27047/remover-a-op%C3%A7%C3%A3o-de-alterar-cep-no-carrinho-quando-usu%C3%A1rio-estiver-identificado)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->