### PR TITLE
Add checkout's major version to useCheckoutURL hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Checkout's major version to `useCheckoutURL`.
+
 ## [0.14.2] - 2020-01-02
 ### Changed
 - Entrypoint file extensions from `.js` to `.tsx` so their types can be exported.

--- a/react/utils/useCheckoutURL.tsx
+++ b/react/utils/useCheckoutURL.tsx
@@ -16,10 +16,10 @@ export const useCheckoutURL = () => {
   })
 
   const version = data?.installedApp?.version
+  const major = version && parseInt(version.split('.')[0])
+
   return {
-    url:
-      version && parseInt(version.split('.')[0]) > 0
-        ? CHECKOUT_URL.V1
-        : CHECKOUT_URL.V0,
+    url: major > 0 ? CHECKOUT_URL.V1 : CHECKOUT_URL.V0,
+    major,
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

We need to decide whether we should use the `render-runtime` `navigate` function to proceed to cart or not. To accomplish that, this PR adds the checkout's major version to `useCheckoutURL`, so we can know if the new checkout is installed.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

**Account with the new checkout installed**
- Proceed to [Workspace](https://jeffaddepum--checkoutio.myvtex.com/?)
- Open the minicart
- Proceed to cart
- Check for the loading bar on top

**Account without the new checkout**
- Proceed to [Workspace](http://jeff--storecomponents.myvtex.com/?)
- Open the minicart
- Proceed to cart
- Verify that the loading bar is not appearing anymore

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/28348/eu-como-comprador-tendo-visitado-a-loja-n%C3%A3o-quero-ver-o-carregamento-do-carrinho)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️| Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
