### PR TITLE
Add id to OrderFormFragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `id` to `OrderFormFragment`.
+
 ## [0.15.0] - 2020-01-07
 
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -1,6 +1,7 @@
 #import './address.graphql'
 
 fragment OrderFormFragment on OrderForm {
+  id
   items {
     additionalInfo {
       brandName


### PR DESCRIPTION
#### What problem is this solving?

Make it possible to pass the orderForm id to pixels.

#### How should this be manually tested?

[Workspace](https://breno--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Depends on:
https://github.com/vtex/checkout-graphql/pull/44