### PR TITLE
Separate queries and mutations into separate exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Separate entrypoints for each query and mutation.
+
 ## [0.17.0] - 2020-02-13
 
 ### Added

--- a/react/MutationAddToCart.js
+++ b/react/MutationAddToCart.js
@@ -1,0 +1,3 @@
+import addToCart from './mutations/addToCart.graphql'
+
+export default addToCart

--- a/react/MutationEstimateShipping.js
+++ b/react/MutationEstimateShipping.js
@@ -1,0 +1,3 @@
+import estimateShipping from './mutations/estimateShipping.graphql'
+
+export default estimateShipping

--- a/react/MutationInsertCoupon.js
+++ b/react/MutationInsertCoupon.js
@@ -1,0 +1,3 @@
+import insertCoupon from './mutations/insertCoupon.graphql'
+
+export default insertCoupon

--- a/react/MutationSaveCards.js
+++ b/react/MutationSaveCards.js
@@ -1,0 +1,3 @@
+import saveCards from './mutations/saveCards.graphql'
+
+export default saveCards

--- a/react/MutationSavePaymentToken.js
+++ b/react/MutationSavePaymentToken.js
@@ -1,0 +1,3 @@
+import savePaymentToken from './mutations/savePaymentToken.graphql'
+
+export default savePaymentToken

--- a/react/MutationSelectDeliveryOption.js
+++ b/react/MutationSelectDeliveryOption.js
@@ -1,0 +1,3 @@
+import selectDeliveryOption from './mutations/selectDeliveryOption.graphql'
+
+export default selectDeliveryOption

--- a/react/MutationUpdateItems.js
+++ b/react/MutationUpdateItems.js
@@ -1,0 +1,3 @@
+import updateItems from './mutations/updateItems.graphql'
+
+export default updateItems

--- a/react/Mutations.tsx
+++ b/react/Mutations.tsx
@@ -1,3 +1,6 @@
+/** DEPRECATED, being kept just for retrocompatibility.
+ * Create individual entry points for each mutation instead */
+
 import addToCart from './mutations/addToCart.graphql'
 import estimateShipping from './mutations/estimateShipping.graphql'
 import insertCoupon from './mutations/insertCoupon.graphql'

--- a/react/Queries.tsx
+++ b/react/Queries.tsx
@@ -1,3 +1,6 @@
+/** DEPRECATED, being kept just for retrocompatibility.
+ * Create individual entry points for each query instead */
+
 import orderForm from './queries/orderForm.graphql'
 import cardSessionId from './queries/cardSessionId.graphql'
 

--- a/react/QueryCardSessionId.js
+++ b/react/QueryCardSessionId.js
@@ -1,0 +1,3 @@
+import cardSessionId from './queries/cardSessionId.graphql'
+
+export default cardSessionId

--- a/react/QueryOrderForm.js
+++ b/react/QueryOrderForm.js
@@ -1,0 +1,3 @@
+import orderForm from './queries/orderForm.graphql'
+
+export default orderForm


### PR DESCRIPTION
#### What problem is this solving?

Create separate entry points for each query and mutation.

Big `export default`ed objects are not properly trimmed and "tree-shaken", and result in large payloads and longer load times

Queries and mutations should now be imported like:
`import addToCart from 'vtex.checkout-resources/MutationAddToCart'`

instead of

`import { addToCart } from 'vtex.checkout-resources'`

#### How should this be manually tested?

`vtex link`

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
