### PR TITLE
Change updateOrderFormProfile mutation input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update `updateOrderFormProfile` mutation variables to match new signature.
+
 ## [0.20.3] - 2020-03-03
 
 ### Changed

--- a/react/mutations/updateOrderFormProfile.graphql
+++ b/react/mutations/updateOrderFormProfile.graphql
@@ -1,7 +1,7 @@
 # import '../fragments/orderForm.graphql'
 
-mutation UpdateOrderFormProfile($email: String!) {
-  updateOrderFormProfile(email: $email) {
+mutation UpdateOrderFormProfile($profile: UserProfileInput!) {
+  updateOrderFormProfile(input: $profile) {
     ...OrderForm
   }
 }

--- a/react/mutations/updateOrderFormProfile.graphql
+++ b/react/mutations/updateOrderFormProfile.graphql
@@ -2,6 +2,6 @@
 
 mutation UpdateOrderFormProfile($profile: UserProfileInput!) {
   updateOrderFormProfile(input: $profile) {
-    ...OrderForm
+    ...OrderFormFragment
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -30,7 +30,8 @@
     "apollo-client": "^2.5.1",
     "typescript": "3.7.3",
     "vtex.apps-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.5.0/public/@types/vtex.apps-graphql",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.22.0/public/@types/vtex.checkout-graphql",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.90.5/public/@types/vtex.render-runtime"
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql",
+    "vtex.gateway-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.gateway-graphql@1.0.0/public/@types/vtex.gateway-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5003,13 +5003,17 @@ verror@1.10.0:
   version "2.5.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.5.0/public/@types/vtex.apps-graphql#be1baf4e27525a942882e09b98ffbceeef20dcbd"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.22.0/public/@types/vtex.checkout-graphql":
-  version "0.22.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.22.0/public/@types/vtex.checkout-graphql#8431798aa058506b3a67a50b14e0a836400abf4b"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql":
+  version "0.24.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql#e970aec45ec8062587fc7d1ad73a6b93ab2ea26a"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.90.5/public/@types/vtex.render-runtime":
-  version "8.90.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.90.5/public/@types/vtex.render-runtime#465f09d3beeae5af81e64a0b84d39af05aefbb66"
+"vtex.gateway-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.gateway-graphql@1.0.0/public/@types/vtex.gateway-graphql":
+  version "1.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.gateway-graphql@1.0.0/public/@types/vtex.gateway-graphql#ce0ac5080c24ff251a1db63eb631dc1fc368636b"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime":
+  version "8.94.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime#e79eb9a66801476b66e7ed354a83a7ff1f1c72c7"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?
Updates the input of the `updateOrderFormProfile` mutation to allow all possible fields to be updated, instead of only the email. Depends on vtex/checkout-graphql#47

[Related clubhouse story](https://app.clubhouse.io/vtex/story/32809/extrair-l%C3%B3gica-de-profile-do-checkout-identification)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout/identification)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->