### PR TITLE
Add userProfileId to OrderFormFragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Field `userProfileId` to `OrderFormFragment`.
+
 ## [0.22.0] - 2020-03-11
 
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -55,6 +55,7 @@ fragment OrderFormFragment on OrderForm {
     uniqueId
   }
   canEditData
+  userProfileId
   marketingData {
     coupon
     utmCampaign


### PR DESCRIPTION
#### What problem is this solving?
Adds the field to the `OrderFormFragment` so we can use it from the `orderForm.graphql` query. Depends on vtex/checkout-graphql#53

[Related clubhouse story](https://app.clubhouse.io/vtex/story/32825/criar-componentes-de-profile-form-e-profile-preview)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->