### PR TITLE
Add resource for updateClientPreferencesData mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Mutation resource to update the client preferences data.
+
 ## [0.23.0] - 2020-03-18
 
 ### Added

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vtex-apps/checkout-ui

--- a/react/MutationUpdateClientPreferencesData.tsx
+++ b/react/MutationUpdateClientPreferencesData.tsx
@@ -1,0 +1,3 @@
+import updateClientPreferencesData from './mutations/updateClientPreferencesData.graphql'
+
+export default updateClientPreferencesData

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -117,6 +117,10 @@ fragment OrderFormFragment on OrderForm {
     documentType
     phone
   }
+  clientPreferencesData {
+    locale
+    optinNewsLetter
+  }
   messages {
     couponMessages {
       code

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -119,7 +119,7 @@ fragment OrderFormFragment on OrderForm {
   }
   clientPreferencesData {
     locale
-    optinNewsLetter
+    optInNewsletter
   }
   messages {
     couponMessages {

--- a/react/mutations/updateClientPreferencesData.graphql
+++ b/react/mutations/updateClientPreferencesData.graphql
@@ -1,0 +1,7 @@
+# import '../fragments/orderForm.graphql'
+
+mutation UpdateClientPreferencesData($clientPreferences: ClientPreferencesDataInput!) {
+  updateClientPreferencesData(input: $clientPreferences) {
+    ...OrderFormFragment
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?
Adds the mutation for use inside the `order-profile` app. Depends on vtex/checkout-graphql#54

[Related story](https://app.clubhouse.io/vtex/story/32825/criar-componentes-de-profile-form-e-profile-preview)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->