### PR TITLE
Adding userType to the available fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Field `userType` to `OrderFormFragment`.
 
-
 ## [0.24.0] - 2020-03-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Field `userType` to `OrderFormFragment`.
+
+
 ## [0.24.0] - 2020-03-20
 
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -56,6 +56,7 @@ fragment OrderFormFragment on OrderForm {
   }
   canEditData
   userProfileId
+  userType
   marketingData {
     coupon
     utmCampaign


### PR DESCRIPTION
This change meant to provide validation for B2B applications where is important to check user's profile type before submitting orders with special needs such as callCenterOperator

#### What problem is this solving?
Before placing an order that requires callCenterOperator credentials we must check userType, this was available before and used by the "save-cart-app", now a new version is being developed

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[wender--sandboxusdev.myvtex.com/orderquote/view/e5143c5f-6554-11ea-831d-12d3e920cd55](https://wender--sandboxusdev.myvtex.com/orderquote/view/e5143c5f-6554-11ea-831d-12d3e920cd55)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
