### PR TITLE
Add refId to the orderForm query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `refId` to the `orderForm` query.
 
 ## [0.25.0] - 2020-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Add `refId` to the `orderForm` query.
+- `refId` to the `orderForm` query.
 
 ## [0.25.0] - 2020-03-24
 

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -53,6 +53,7 @@ fragment OrderFormFragment on OrderForm {
       fieldValues
     }
     uniqueId
+    refId
   }
   canEditData
   userProfileId


### PR DESCRIPTION
#### What problem is this solving?

Dependent of:
- https://github.com/vtex/checkout-graphql/pull/57

Related to:
- https://app.clubhouse.io/vtex/story/33546/add-skurefid-to-pixel-cart-events

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
