### PR TITLE
Add setCheckoutCookie argument to orderForm query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `refId` to the `orderForm` query.
 
 ## [0.25.0] - 2020-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Add `refId` to the `orderForm` query.
+- `refId` to the `orderForm` query.
 
 ## [0.25.0] - 2020-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.26.0] - 2020-03-25
 ### Added
 - `refId` to the `orderForm` query.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.26.0] - 2020-03-25
 ### Added
+
+- `setCheckoutCookie` argument to `orderForm` query.
+
+## [0.26.0] - 2020-03-25
+
+### Added
+
 - `refId` to the `orderForm` query.
 
 ## [0.25.0] - 2020-03-24

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "checkout-resources",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "title": "Checkout Resources",
   "description": "Checkout Resources",
   "defaultLocale": "pt-BR",

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -53,6 +53,7 @@ fragment OrderFormFragment on OrderForm {
       fieldValues
     }
     uniqueId
+    refId
   }
   canEditData
   userProfileId

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.checkout-resources",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "license": "UNLICENSED",
   "scripts": {

--- a/react/queries/orderForm.graphql
+++ b/react/queries/orderForm.graphql
@@ -1,7 +1,7 @@
 # import '../fragments/orderForm.graphql'
 
-query orderForm {
-  orderForm {
+query orderForm($setCheckoutCookie: Boolean) {
+  orderForm(setCheckoutCookie: $setCheckoutCookie) {
     ...OrderFormFragment
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Enable users to pass the new `setCheckoutCookie` argument to the `orderForm` query.
The more detailed motivation for this change is described at [checkout-graphql](https://github.com/vtex/checkout-graphql/pull/58) and [store](https://github.com/vtex-apps/store/pull/442).

#### How should this be manually tested?

(This is the same process described at https://github.com/vtex-apps/store/pull/442)

1. Go to [this workspace](https://victorhmp--storecomponents.myvtex.com/), where there is only the new `OrderFormProvider` being used (`orderFormOptimization` is enabled), and see that the store is functioning as it should;
2. Go to [this workspace](https://victorhmp--alssports.myvtex.com/) where there are **two** `OrderFormProvider`s being used, along with the legacy `minicart` and `buy-button` blocks, instead of the new ones, which means they consume and alter the legacy `OrderFormContext`;
3. Check that adding, removing and changing the number of items in the `minicart` all work as expected.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Depends on: https://github.com/vtex/checkout-graphql/pull/58
