### PR TITLE
Add unitMultiplier to items in orderForm fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Field `unitMultiplier` to `items` in `OrderFormFragment`.
 
 ## [0.29.0] - 2020-05-05
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -52,6 +52,7 @@ fragment OrderFormFragment on OrderForm {
       fieldName
       fieldValues
     }
+    unitMultiplier
     uniqueId
     refId
   }


### PR DESCRIPTION
#### What problem is this solving?

This adds `unitMultiplier` as a field of `items` so it can be used to properly treat the case when `unitMultiplier` is not `1`.

#### How should this be manually tested?

Follow the test plan of https://github.com/vtex-apps/product-list/pull/55.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/36921/investigar-problemas-com-unitmultiplier-no-cart)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
