### PR TITLE
Fix profile query not destructuring availableAccounts fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Query for `profile` not destructuring fields of `availableAccounts`.
 
 ## [0.30.0] - 2020-05-08
 ### Added

--- a/react/queries/profile.graphql
+++ b/react/queries/profile.graphql
@@ -2,7 +2,13 @@ query ProfileQuery($email: String!) {
   checkoutProfile(email: $email) {
     userProfileId
     profileProvider
-    availableAccounts
+    availableAccounts {
+      accountId
+      paymentSystem
+      paymentSystemName
+      cardNumber
+      bin
+    }
     userProfile {
       email
       firstName


### PR DESCRIPTION
#### What problem is this solving?

Fixes the `profile` query not retrieving required fields for non-scalar type `AvailableAccounts`.

#### How should this be manually tested?

[Workspace](https://steps--checkoutio.myvtex.com/cart).

You can follow the same test plan as vtex/checkout-graphql#75.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->