### PR TITLE
CHUI-67: Add fields loggedIn and isDisposable to orderForm and address fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Field `loggedIn` to `OrderFormFragment` fragment.
+- Field `isDisposable` to `Address` fragment.
 
 ## [0.31.0] - 2020-07-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Field `loggedIn` to `OrderFormFragment` fragment.
 
 ## [0.31.0] - 2020-07-07
 ### Added

--- a/react/fragments/address.graphql
+++ b/react/fragments/address.graphql
@@ -11,4 +11,5 @@ fragment Address on Address {
   reference
   state
   street
+  isDisposable
 }

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -57,6 +57,7 @@ fragment OrderFormFragment on OrderForm {
     refId
   }
   canEditData
+  loggedIn
   userProfileId
   userType
   marketingData {


### PR DESCRIPTION
#### What problem is this solving?

Adds the field `loggedIn` to the order form fragment so we can use it in the React components.

#### How should this be manually tested?

[Workspace](https://sndpurchase--checkoutio.myvtex.com/). Follow the same test plan as vtex/checkout-graphql#77.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->