### PR TITLE
CHUI-9: Add field isValid to order form attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Include field `isValid` in `OrderFormFragment` attachments.
 
 ## [0.30.1] - 2020-06-04
 ### Fixed

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -87,6 +87,7 @@ fragment OrderFormFragment on OrderForm {
       estimate
       isSelected
     }
+    isValid
   }
   paymentData {
     paymentSystems {
@@ -137,6 +138,7 @@ fragment OrderFormFragment on OrderForm {
       cardNumber
       bin
     }
+    isValid
   }
   clientProfileData {
     email
@@ -145,6 +147,7 @@ fragment OrderFormFragment on OrderForm {
     document
     documentType
     phone
+    isValid
   }
   clientPreferencesData {
     locale


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the `isValid` field to the order form attachments (client, shipping and payment data) so we can add the redirection logic for the user to be in the latest invalid step. Depends on vtex/checkout-graphql#78

#### How should this be manually tested?

[Workspace](https://steps--checkoutio.myvtex.com/). You can follow the same test plan as the PR linked above.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->