### PR TITLE
Add seller to orderForm query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Field `seller` to `OrderFormFragment` fragment.
 
 ## [0.32.0] - 2020-07-09
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -46,6 +46,7 @@ fragment OrderFormFragment on OrderForm {
     productRefId
     productId
     quantity
+    seller
     sellingPrice
     skuName
     skuSpecifications {


### PR DESCRIPTION
#### What problem is this solving?

Add missing `seller` information to the order form fragment

#### How should this be manually tested?

https://addadd--storecomponents.myvtex.com/blouse-with-knot/p?skuId=310124164

https://addadd--storecomponents.myvtex.com/_v/private/vtex.checkout-graphql@0.36.5/graphiql/v1?query=%7B%0A%20%20orderForm%20%7B%0A%20%20%20%20id%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20seller%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Screenshot

![image](https://user-images.githubusercontent.com/12702016/92023244-e1c2a900-ed32-11ea-822b-3012344abb1f.png)


#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
