### PR TITLE
Feature/price tags field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - Field `priceTags` to `OrderFormFragment` fragment.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Field `priceTags` to `OrderFormFragment` fragment.
+
 ## [0.36.0] - 2020-09-28
 ### Added
 - Field `manualPrice` to `OrderFormFragment` fragment.

--- a/react/fragments/item.graphql
+++ b/react/fragments/item.graphql
@@ -78,4 +78,18 @@ fragment ItemFragment on Item {
   unitMultiplier
   uniqueId
   refId
+  priceTags {
+    identifier
+    isPercentual
+    rawValue
+    value
+    name
+    ratesAndBenefitsIdentifier {
+      description
+      id
+      featured
+      name
+      matchedParameters
+    }
+  }
 }


### PR DESCRIPTION
#### What problem is this solving?

Add the field `priceTags` on `ItemsFragment` to make possible to see priceTags on ItemsContext, so we can differ products with same id
This PR is dependent on this one and could be tested in same way: https://github.com/vtex-apps/checkout-graphql/pull/101

#### How should this be manually tested?

[Workspace](https://pac--carrefourbrfood.myvtex.com/chocolate-ao-leite-bis-126g-9284230/p)

Access the workspace above and add four units of this product on cart, if you still didn't regionalize you won't be able to add the product to the cart, you can use this postal code for regionalize: 04814-620. Then open the minicart and see if the free product is in the cart. Then open the console and see the Item Context message and you can see the priceTags:
![image](https://user-images.githubusercontent.com/59736416/95478752-52776980-0960-11eb-8c2a-6a34cd54372b.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
