### PR TITLE
CHK-464: Add resource for clearOrderFormMessages mutation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,9 @@
 
 - [ ] Updated `README.md`.
 - [ ] Updated `CHANGELOG.md`.
-- [ ] Linked this PR to a Clubhouse story (if applicable).
+- [ ] Linked this PR to a Jira story (if applicable).
 - [ ] Updated/created tests (important for bug fixes).
 - [ ] Deleted the workspace after merging this PR (if applicable).
-
-#### Screenshots or example usage
 
 #### Type of changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Mutation `clearOrderFormMessages`.
 
 ## [0.37.0] - 2020-10-30
 ### Added

--- a/react/MutationClearOrderFormMessages.tsx
+++ b/react/MutationClearOrderFormMessages.tsx
@@ -1,0 +1,3 @@
+import clearOrderFormMessages from './mutations/clearOrderFormMessages.graphql'
+
+export default clearOrderFormMessages

--- a/react/mutations/clearOrderFormMessages.graphql
+++ b/react/mutations/clearOrderFormMessages.graphql
@@ -1,0 +1,7 @@
+# import '../fragments/orderForm.graphql'
+
+mutation ClearOrderFormMessages($orderFormId: ID!) {
+  clearOrderFormMessages(orderFormId: $orderFormId) {
+    ...OrderFormFragment
+  }
+}

--- a/react/package.json
+++ b/react/package.json
@@ -28,7 +28,7 @@
     "@types/react-intl": "^2.3.17",
     "@vtex/test-tools": "^2.1.1",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.apps-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.5.1/public/@types/vtex.apps-graphql",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.39.1/public/@types/vtex.checkout-graphql",
     "vtex.gateway-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.gateway-graphql@1.0.0/public/@types/vtex.gateway-graphql",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4888,10 +4888,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.7.3"


### PR DESCRIPTION
#### What problem is this solving?

Adds the resource for the mutation `clearOrderFormMessages`.

#### How should this be manually tested?

[Workspace](https://toasts--checkoutio.myvtex.com/).

Follow the same test plan as vtex-apps/checkout-graphql#106.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
