### PR TITLE
added marketingTags field on orderForm fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `marketingTags` field on orderForm fragment to retrieve value throught [vtex.order-manager](https://github.com/vtex-apps/order-manager#orderform-orderform) orderForm context.
+
 ## [0.40.0] - 2020-12-02
 ### Added
 - Field `parentItemIndex` to `OrderFormFragment` fragment.

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -18,6 +18,7 @@ fragment OrderFormFragment on OrderForm {
     utmiCampaign
     utmiPart
     utmiPage
+    marketingTags
   }
   totalizers {
     id


### PR DESCRIPTION
#### What problem is this solving?

Make able to retrieve `marketingTags` in orderForm using [order-manager](https://github.com/vtex-apps/order-manager#orderform-orderform)

#### How should this be manually tested?

Implementing [useOrderForm](https://github.com/vtex-apps/order-manager#usage) hook like the example, you will be able to retrieve this data on orderForm.

[Workspace](https://marketingtags--dzarm.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
