### PR TITLE
Update apps-graphql dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Usage of `installedApp` query, replaced by a more performatic query
 
 ## [0.41.1] - 2021-01-19
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "vtex.checkout-graphql": "0.x",
     "vtex.gateway-graphql": "1.x",
-    "vtex.apps-graphql": "2.x"
+    "vtex.apps-graphql": "3.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/utils/graphql/installedApp.graphql
+++ b/react/utils/graphql/installedApp.graphql
@@ -1,5 +1,5 @@
 query installedApp($slug: String!) {
-  installedApp(slug: $slug) {
+  installedApp: installedAppPublic(slug: $slug) {
     version
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Update `vtex.apps-graphql` dependency from `2.x` to `3.x`. This enables this app to use the `installedAppPublic` query, which is cacheable, diminishing general latency for this app.

#### How should this be manually tested?

You can test this by navigating this [workspace](https://chkres--carrefourbr.myvtex.com/).

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

None
