### PR TITLE
CHK-408: Add priceTags field to Item fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Property `priceTags` to `Item` fragment.
 
 ## [0.42.0] - 2021-02-23
 ### Added

--- a/react/fragments/item.graphql
+++ b/react/fragments/item.graphql
@@ -64,6 +64,13 @@ fragment ItemFragment on Item {
     }
   }
   price
+  priceTags {
+    identifier
+    isPercentual
+    name
+    rawValue
+    value
+  }
   productCategories
   productCategoryIds
   productRefId


### PR DESCRIPTION
#### What problem is this solving?

Adds the `priceTags` field to `Item` fragment to be used in a upcoming feature.

#### How should this be manually tested?

[Workspace](https://pldiscounts--checkoutio.myvtex.com/cart/add?sku=349&qty=7&seller=1&sku=349&qty=3&seller=1&sku=354&qty=12&seller=1&sku=356&qty=9&seller=1&sku=356&qty=1&seller=1&sku=353&qty=9&seller=1&sku=353&qty=1&seller=1&sku=360&qty=2&seller=1&sku=360&qty=1&seller=1)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
