### PR TITLE
Feat/item is gift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Property `isGift` to `Item` fragment.
+
 ## [0.43.0] - 2021-03-22
 ### Added
 - Property `priceTags` to `Item` fragment.

--- a/react/fragments/item.graphql
+++ b/react/fragments/item.graphql
@@ -100,4 +100,5 @@ fragment ItemFragment on Item {
       matchedParameters
     }
   }
+  isGift
 }


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This code brings the `isGift` field into the `Item` query fragment. It supports a development of a feature request by Whirlpool, an European T1 client. The feature is in this [PR](https://github.com/vtex-apps/order-items/pull/42)

#### How should this be manually tested?

This [workspace](https://giftcart--itwhirlpool.myvtex.com) has this branch linked. During the initial fetches, it's possible to see the query from `vtex.checkout-resources@0.x` to `vtex.checkout-graphql@0.x` bringing the products with the `isGift` property, as in the image below.

![Screen Shot 2021-04-07 at 11 57 20 AM](https://user-images.githubusercontent.com/38737958/113848730-0f744280-9799-11eb-85cf-c57f235f77f1.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

This code relies on the merge of [this PR](https://github.com/vtex-apps/checkout-graphql/pull/127) to `vtex.checkout-graphql`. Otherwise, it breaks the queries fetching `Item`.