### PR TITLE
Add customData field to orderForm

### DIFF
--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -125,6 +125,13 @@ fragment OrderFormFragment on OrderForm {
     locale
     optInNewsletter
   }
+  customData {
+    customApps {
+      fields
+      id
+      major
+    }
+  }
   messages {
     couponMessages {
       code


### PR DESCRIPTION
What problem is this solving?
Currently the context useOrderForm provides only a summary of data. The idea of this PR is to provide the possibility to access the custom data field directly from the context.
https://ibb.co/gvmxY6j

Facilitate access to the 'custom data' field via context.

Associated pull request https://github.com/vtex-apps/checkout-graphql/pull/130