### PR TITLE
Adding gclid to orderform's marketing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `gclid` to orderForm query
 
 ## [0.46.0] - 2021-04-16
 

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -12,6 +12,7 @@ fragment OrderFormFragment on OrderForm {
   userType
   marketingData {
     coupon
+    gclid
     utmCampaign
     utmMedium
     utmSource


### PR DESCRIPTION
#### What problem is this solving?

Currently, a store's revenue cannot be linked to a Google Adwords campaign because it missed the `gclid` when sending the orderPlaced data to GTM. This PR adds `gclid` to the marketing data so it can be used by GTM.

#### How should this be manually tested?

[Workspace](https://icaro--storecomponents.myvtex.com/?gclid=testeidgoogle/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This PR is related to https://github.com/vtex-apps/checkout-graphql/pull/154
