### PR TITLE
ModalType prop added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased]+
+
+### Added
+- `modalType` props in `orderForm/item` fragment.
 
 ## [0.48.0] - 2022-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]+
+## [Unreleased]
 
 ### Added
 - `modalType` props in `orderForm/item` fragment.

--- a/react/fragments/item.graphql
+++ b/react/fragments/item.graphql
@@ -51,6 +51,7 @@ fragment ItemFragment on Item {
   listPrice
   manualPrice
   measurementUnit
+  modalType
   name
   offerings {
     id


### PR DESCRIPTION
#### What problem is this solving?

The fragments of  orderForm/item hasn't modalType prop, we create a PR to have it in [checkout-graphql](https://github.com/vtex-apps/checkout-graphql/pull/175).

