### PR TITLE
Add `availableQuantity` to `orderForm/item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `availableQuantity` props in `orderForm/item` fragment.
+
 ## [0.49.0] - 2022-06-01
 ### Added
 - Accepts Order Form ID via query parameter on orderForm query

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "checkout-resources",
-  "version": "0.49.0",
+  "version": "0.50.0-beta.0",
   "title": "Checkout Resources",
   "description": "Checkout Resources",
   "defaultLocale": "pt-BR",

--- a/react/fragments/item.graphql
+++ b/react/fragments/item.graphql
@@ -41,6 +41,7 @@ fragment ItemFragment on Item {
     }
   }
   availability
+  availableQuantity
   detailUrl
   id
   imageUrls {


### PR DESCRIPTION
#### What problem is this solving?

See https://github.com/vtex-apps/checkout-graphql/pull/187 for more context. As far as I understood, once we added the new `availableQuantity` field we also need to add it to the `Item` fragment so it would be queried and returned to the items in the minicart app.

#### How should this be manually tested?

Before|After
-|-
![Before](https://user-images.githubusercontent.com/381395/213585868-52ed72a6-9ea1-4838-a1c5-18531fa6b108.gif)|![After](https://user-images.githubusercontent.com/381395/213585877-aa1ff4eb-002e-458c-800e-6e9f5b611eab.gif)

On this PDP, the max availability for the product is 3. Add the product to the cart, and, in the mini cart, you shouldn't be able to increase its quantity past 3, even if you click quickly.

[Workspace](https://ki564283filipelima--lojadokadu.myvtex.com/livro/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

- https://github.com/vtex-apps/checkout-graphql/pull/187 where the field has been added.
- https://github.com/vtex-apps/product-list/pull/144 where the field is going to be used.