### PR TITLE
Add `storePreferencesData` and `cooporate fields` to order form query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `storePreferencesData` structure in `orderForm` fragment.
+- `corporateName`, `corporateDocument` and `corporatePhone` in  `orderForm` fragment.
+
 ## [0.49.0] - 2022-06-01
 ### Added
 - Accepts Order Form ID via query parameter on orderForm query

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -119,11 +119,26 @@ fragment OrderFormFragment on OrderForm {
     document
     documentType
     phone
+    corporateName
+    corporateDocument
+    corporatePhone
     isValid
   }
   clientPreferencesData {
     locale
     optInNewsletter
+  }
+  storePreferencesData {
+    countryCode
+    currencyCode
+    timeZone
+    currencyFormatInfo {
+      currencyDecimalDigits
+      currencyDecimalSeparator
+      currencyGroupSeparator
+      startsWithCurrencySymbol
+    }
+    currencySymbol
   }
   messages {
     couponMessages {


### PR DESCRIPTION
#### What problem is this solving?
- Currently store preference data is not included in the `orderform` query this information is useful for formatting the currency. 
- For B2B stores `corporateName` and `corporateDocument` will be accessible from the `orderform` context.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

- Add `storePreferencesData` structure in `orderForm` fragment.
- Add `corporateName`, `corporateDocument` and `corporatePhone` in  `orderForm` fragment.
