### PR TITLE
add: possibility to split or not items with attachments when increasing quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `splitItem` in `updateItems` mudation
 
 ## [0.49.0] - 2022-06-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `splitItem` in `updateItems` mudation
+- `splitItem` in `updateItems` mutation
 
 ## [0.49.0] - 2022-06-01
 ### Added

--- a/react/mutations/updateItems.graphql
+++ b/react/mutations/updateItems.graphql
@@ -3,10 +3,12 @@
 mutation updateItems(
   $orderItems: [ItemInput]
   $allowedOutdatedData: [String!]
+  $splitItem: Boolean
 ) {
   updateItems(
     orderItems: $orderItems
     allowedOutdatedData: $allowedOutdatedData
+    splitItem: $splitItem
   ) {
     ...OrderFormFragment
   }


### PR DESCRIPTION
#### What problem is this solving?

This PR aims to fix (add a new param) to the KI: #337069

If a store uses the [product-list](https://developers.vtex.com/vtex-developer-docs/docs/vtex-product-list) component of [Store Framework](https://developers.vtex.com/vtex-developer-docs/docs/getting-started-3), used in the [minicart](https://vtex.io/docs/components/all/vtex.minicart@2.61.1/), cart items may be duplicated when increasing the quantity of an item that has an [attachment](https://help.vtex.com/en/tutorial/adding-an-attachment--7zHMUpuoQE4cAskqEUWScU#) (itemAttachment).

This is because the default [noSplitItem behavior of the API request that updates cart items is false](https://github.com/vtex/vcs.checkout/blob/71bb65b67a94de30b74d4f0ea648f0c61ea43438/src/VTEX%20Checkout/Private%20Assemblies/Vtex.Commerce.Checkout.WebApi/Controllers/OrderFormApiController.cs#L330).

-----

With this PR, now, it's possible to add a prop splitItem in minicart-product-list, so, the customer will choose if they want or not to split the products in minicart. 

#### How to test it?

- Add a [product with attachments](https://iespinoza--storecomponents.myvtex.com/star-color-top/p?__bindingAddress=storetheme.vtex.com/) in cart.
- Open mini cart
- Increase the quantity of the product with attachments

Expected: Just increase the quantity of the product (A.K.A increase the SKU of a single product)
What was happening: Splitting the product into different products with only 1 quantity

The variables in the mutation should look like this

![image](https://github.com/vtex-apps/checkout-resources/assets/13649073/6db884ec-d414-463c-a8ba-499fb720b905)

Currently, we always [send the prop splitItem as true in checkout-graphql ](https://github.com/vtex-apps/checkout-graphql/blob/ed460b253a047a84932908261b28df1b47740720/graphql/schema.graphql#L34)

#### Screenshots or example usage:

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Before](https://master--storecomponents.myvtex.com/star-color-top/p?__bindingAddress=storetheme.vtex.com/)

https://github.com/vtex-apps/minicart/assets/13649073/5cbab702-5495-4de6-a626-1bf4ba2f1dec


[After](https://iespinoza--storecomponents.myvtex.com/star-color-top/p?__bindingAddress=storetheme.vtex.com/)

![image](https://github.com/vtex-apps/minicart/assets/13649073/dea6e3ed-e3f5-45c1-b7cd-2fb551deb5c7)


<!--- Add some images or gifs to showcase changes in behavior or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

 We keep the same default behavior (split = true), even though several clients were complaining about that. 
The positive side effect is that this is not going to affect any live store
The negative side effect is that the client will have to change their theme in order to fix/change this behavior

#### Related to / Depends on

https://github.com/vtex-apps/minicart/pull/334
https://github.com/vtex-apps/product-list/pull/159
https://github.com/vtex/order-items/pull/38

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2c2c2FzZG9ocHFqZ2Y4em1tNnN4OWJ2NHcxaDdqdndtM256ajhmeCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZPOqQ7F22lf7q/giphy.gif)
