### PR TITLE
feat: Support Corporate fields at orderForm profile level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `orderForm` query now returns `clientProfileData` with corporate fields `isCorporate`, `corporateName`, `tradeName`, `corporateDocument`, `stateInscription`.
 
 ## [0.50.0] - 2024-09-05
 ### Added

--- a/react/fragments/orderForm.graphql
+++ b/react/fragments/orderForm.graphql
@@ -120,6 +120,11 @@ fragment OrderFormFragment on OrderForm {
     documentType
     phone
     isValid
+    isCorporate
+    corporateName
+    tradeName
+    corporateDocument
+    stateInscription
   }
   clientPreferencesData {
     locale


### PR DESCRIPTION
#### What problem is this solving?

Support corporate fields in orderforms

#### How should this be manually tested?

When loading the orderForm you should be able to see the corporate fields of the customer profile.

#### Checklist/Reminders

- [X] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
